### PR TITLE
Add Tracking of Project Root

### DIFF
--- a/cogs/project.scm
+++ b/cogs/project.scm
@@ -1,0 +1,84 @@
+(require "steel/logging/log.scm")
+
+(require "helix/editor.scm")
+(require "helix/misc.scm")
+
+(provide get-project-root
+         set-project-root!
+         get-project-helix
+         in-project-helix
+         set-project-helix!)
+
+(define PROJECT-ROOT "./")
+(define PROJECT-HELIX #f)
+
+(define (get-project-root)
+  PROJECT-ROOT)
+
+(define (set-project-root! path)
+  (if (ends-with? path "/")
+      (set! PROJECT-ROOT path)
+      (set! PROJECT-ROOT (string-append path "/"))))
+
+(define (get-project-helix-path)
+  (if PROJECT-HELIX
+    PROJECT-HELIX
+    (string-append PROJECT-ROOT ".helix/")))
+
+(define (get-project-helix)
+  (define path (get-project-helix-path))
+  
+  (unless (path-exists? path)
+    (create-directory! path))
+  
+  path)
+
+(define (in-project-helix path)
+  (string-append (get-project-helix) path))
+
+(define (set-project-helix! path)
+  (if (ends-with? path "/")
+      (set! PROJECT-HELIX path)
+      (set! PROJECT-HELIX (string-append path "/"))))
+
+;;;;;;;;;;;;; Perform default project location picking ;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define DEFAULT_PROJECT_ROOT "./")
+(define DEFAULT_PROJECT_HELIX "~/.config/helix/")
+
+;; Figure out where root of project should be
+(define (find-project-root)
+  (define curr-dir (current-directory))
+
+  (define (exists-and-is-dir? path)
+    (and (path-exists? path) (is-dir? path)))
+  
+  ;; Given dir <<curr>>, if it contains a <<find>> directory, return it.
+  ;; the result of calling helper (parent-name curr).
+  (define (helper curr find)
+    (cond
+      [(string=? curr "") #f] ;; Didn't find after searching all the way to root, return false.
+      [(exists-and-is-dir? (string-append curr "/" find)) curr]
+      [else (helper (parent-name curr) find)]))
+
+  (define ancestor-with-helix (helper curr-dir ".helix"))
+  (define ancestor-with-jj    (helper curr-dir ".jj"))
+  (define ancestor-with-git   (helper curr-dir ".git"))
+
+  (cond
+    [ancestor-with-helix (cons ancestor-with-helix #f)]
+    [ancestor-with-jj    (cons ancestor-with-jj #f)]
+    [ancestor-with-git   (cons ancestor-with-git #f)]
+    [else (cons DEFAULT_PROJECT_ROOT DEFAULT_PROJECT_HELIX)])
+  )
+
+(let ((project-root-and-helix (find-project-root)))
+  (define project-root (car project-root-and-helix))
+  (define project-helix (cdr project-root-and-helix))
+
+  ; (log/info! . (string-append "project-root is " project-root))
+  ; (log/info! . (string-append "project-helix is " project-helix))
+  
+  (set-project-root! project-root)
+  (if project-helix (set-project-helix! project-helix))
+)

--- a/crates/steel-pty/Cargo.lock
+++ b/crates/steel-pty/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
  "notify",
  "once_cell",
  "ordered-float",
- "portable-pty 0.8.1 (git+https://github.com/mattwparas/wezterm.git?branch=mwp-public-scroll)",
+ "portable-pty",
  "promise",
  "serde",
  "serde_json",
@@ -993,17 +993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8090f921a24b04994d9929e204f50b498a33ea6ba559ffaa05e04f7ee7fb5ab"
 dependencies = [
  "simd-adler32",
-]
-
-[[package]]
-name = "filedescriptor"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
-dependencies = [
- "libc",
- "thiserror",
- "winapi",
 ]
 
 [[package]]
@@ -2432,33 +2421,12 @@ dependencies = [
 [[package]]
 name = "portable-pty"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
-dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "downcast-rs",
- "filedescriptor 0.8.2",
- "lazy_static",
- "libc",
- "log",
- "nix 0.25.1",
- "serial",
- "shared_library",
- "shell-words",
- "winapi",
- "winreg",
-]
-
-[[package]]
-name = "portable-pty"
-version = "0.8.1"
 source = "git+https://github.com/mattwparas/wezterm.git?branch=mwp-public-scroll#e1975e6586f7156be8da42308cd2aa19d3a22374"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
  "downcast-rs",
- "filedescriptor 0.8.3",
+ "filedescriptor",
  "lazy_static",
  "libc",
  "log",
@@ -3015,7 +2983,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "steel-core"
 version = "0.6.0"
-source = "git+https://github.com/mattwparas/steel.git#9b2ada576da13ba0eccd667ecf80e2e2ec613dd0"
+source = "git+https://github.com/Talia-12/steel.git#785312ab654d47dd87c5a2b7a137e9fd9e644346"
 dependencies = [
  "abi_stable",
  "anyhow",
@@ -3063,7 +3031,7 @@ dependencies = [
 [[package]]
 name = "steel-derive"
 version = "0.5.0"
-source = "git+https://github.com/mattwparas/steel.git#9b2ada576da13ba0eccd667ecf80e2e2ec613dd0"
+source = "git+https://github.com/Talia-12/steel.git#785312ab654d47dd87c5a2b7a137e9fd9e644346"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3073,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "steel-gen"
 version = "0.2.0"
-source = "git+https://github.com/mattwparas/steel.git#9b2ada576da13ba0eccd667ecf80e2e2ec613dd0"
+source = "git+https://github.com/Talia-12/steel.git#785312ab654d47dd87c5a2b7a137e9fd9e644346"
 dependencies = [
  "codegen",
  "serde",
@@ -3083,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "steel-parser"
 version = "0.6.0"
-source = "git+https://github.com/mattwparas/steel.git#9b2ada576da13ba0eccd667ecf80e2e2ec613dd0"
+source = "git+https://github.com/Talia-12/steel.git#785312ab654d47dd87c5a2b7a137e9fd9e644346"
 dependencies = [
  "compact_str",
  "fxhash",
@@ -3107,7 +3075,7 @@ dependencies = [
  "futures-time",
  "log",
  "parking_lot 0.11.2",
- "portable-pty 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "portable-pty",
  "steel-core",
  "termwiz",
  "tokio",
@@ -3210,7 +3178,7 @@ dependencies = [
  "base64",
  "bitflags 2.6.0",
  "fancy-regex",
- "filedescriptor 0.8.3",
+ "filedescriptor",
  "finl_unicode",
  "fixedbitset",
  "hex",
@@ -3654,13 +3622,13 @@ dependencies = [
  "bitflags 1.3.2",
  "camino",
  "dirs-next",
- "filedescriptor 0.8.3",
+ "filedescriptor",
  "filenamegen",
  "gethostname",
  "libc",
  "libssh-rs",
  "log",
- "portable-pty 0.8.1 (git+https://github.com/mattwparas/wezterm.git?branch=mwp-public-scroll)",
+ "portable-pty",
  "regex",
  "smol",
  "socket2 0.5.7",

--- a/crates/steel-pty/Cargo.toml
+++ b/crates/steel-pty/Cargo.toml
@@ -11,9 +11,9 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-portable-pty = "0.8.1"
+portable-pty = { git = "https://github.com/mattwparas/wezterm.git", branch = "mwp-public-scroll", version = "0.8.1" }
 # steel-core = { path = "/home/matt/Documents/steel/crates/steel-core", features = ["dylibs"] }
-steel-core = { git = "https://github.com/mattwparas/steel.git", version = "0.6.0", features = ["anyhow", "dylibs", "sync"] }
+steel-core = { git = "https://github.com/Talia-12/steel.git", version = "0.6.0", features = ["anyhow", "dylibs", "sync"] }
 abi_stable = "0.11.1"
 futures = "0.3.26"
 tokio = { version = "1.29.1", features = ["sync"]}


### PR DESCRIPTION
This adds a cog which determines which directory should be the project root (which is then where the .helix directory is placed), currently based on searching for existing .helix directories, then .jj directories, then .git directories, saving the project root as the first in the current directories parents that contains a .helix, and then if none do the first containing a .jj, ect. If none are found it uses the helix config folder instead of a .helix folder, which will help prevent .helix folders appearing everywhere. There are also functions provided to allow the user to set the project root and helix paths directly.

IMPORTANT: This relies on the parent-name function in my fork of steel, which I've already made a PR adding to steel. (Also this kind of feels like something that should be determined by helix itself rather than a plugin, but it isn't currently so here we are.)