### PR TITLE
Improved VIM motions and Lazygit terminal

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
 runtime/
 extensions/
 **/target
+
+# Devenv
+.devenv*
+devenv.local.nix
+devenv.local.yaml
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,86 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1780059501,
+        "narHash": "sha256-uN87lpSlC4OWjb9ulH8zn9EyW6XEexn+saWLiCMMvP4=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "2d2f89eee89a7f5db15e0b4ffdcc1f7369ef3eed",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1778507786,
+        "narHash": "sha256-HzSQCKMsMr8r55LwM1JuzIOB+8bzk0FEv6sItKvsfoY=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "8f24a228a782e24576b155d1e39f0d914b380691",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780024773,
+        "narHash": "sha256-aU9nlrS9S+IJ2EiCzsaxzOXUhggogqTrJojBicE6Oeg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "40b0a3a193e0840c76174b4a322874c8f6dd0a63",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,67 @@
+{ pkgs, lib, config, inputs, ... }:
+
+{
+  packages = with pkgs; [
+    git
+    xplr
+    pkg-config
+    openssl
+  ] ++ lib.optionals pkgs.stdenv.isDarwin [
+    pkgs.libiconv
+  ];
+
+  languages.rust = {
+    enable = true;
+    channel = "stable";
+  };
+
+  scripts = {
+    install-steel-forge.exec = ''
+      echo "Installing forge CLI from steel repo..."
+      cargo install --git https://github.com/mattwparas/steel.git steel-forge
+    '';
+
+    install-helix-steel.exec = ''
+      if [ -z "$HELIX_SRC" ]; then
+        echo "Set HELIX_SRC to path of mattwparas/helix clone, or clone it:"
+        echo "  git clone https://github.com/mattwparas/helix \$HOME/helix-steel"
+        echo "  export HELIX_SRC=\$HOME/helix-steel"
+        exit 1
+      fi
+      echo "Building helix with steel from $HELIX_SRC..."
+      (cd "$HELIX_SRC" && cargo xtask steel)
+    '';
+
+    deploy.exec = ''
+      DEST="$HOME/.config/helix/vim"
+      SRC="$(pwd)/vim"
+      if [ ! -d "$SRC" ]; then
+        echo "error: vim/ not found in $(pwd) — run from the repo root"
+        exit 1
+      fi
+      mkdir -p "$DEST"
+      cp "$SRC"/*.scm "$DEST/"
+      echo "Copied $(ls "$SRC"/*.scm | wc -l | tr -d ' ') files → $DEST"
+    '';
+
+    dev-setup.exec = ''
+      echo "=== helix-vim-plugin dev setup ==="
+      echo ""
+      echo "Step 1: install forge CLI"
+      echo "  run: install-steel-forge"
+      echo ""
+      echo "Step 2: clone & build helix fork"
+      echo "  git clone https://github.com/mattwparas/helix ~/helix-steel"
+      echo "  export HELIX_SRC=~/helix-steel"
+      echo "  run: install-helix-steel"
+      echo ""
+      echo "Step 3: install this package"
+      echo "  forge install"
+      echo ""
+    '';
+  };
+
+  enterShell = ''
+    dev-setup
+  '';
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,8 @@
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+  rust-overlay:
+    url: github:oxalica/rust-overlay
+    inputs:
+      nixpkgs:
+        follows: nixpkgs

--- a/term.scm
+++ b/term.scm
@@ -62,6 +62,8 @@
          (contract/out set-default-terminal-rows! (->/c int? void?))
          (contract/out set-default-shell! (->/c string? void?))
          xplr
+         lazygit
+         close-lazygit
          open-debug-window
          close-debug-window
          hide-terminal)
@@ -1157,3 +1159,27 @@
   (when *xplr*
     (stop-terminal *xplr*)
     (set! *xplr* #f)))
+
+(define *lazygit* #f)
+
+(define (lazygit-on-start terminal)
+  (pty-process-send-command (Terminal-*pty-process* terminal)
+                            (string-append "cd " (helix-find-workspace) " && lazygit\r")))
+
+(define (lazygit)
+  (define term
+    (make-terminal "lazygit"
+                   *default-shell*
+                   *default-terminal-rows*
+                   *default-terminal-cols*
+                   lazygit-on-start
+                   vte/advance-bytes))
+  (set! *lazygit* term)
+  (set-TerminalRegistry-terminals! *terminal-registry* (list term))
+  (set-TerminalRegistry-cursor! *terminal-registry* 0)
+  (show-term term))
+
+(define (close-lazygit)
+  (when *lazygit*
+    (kill-active-terminal)
+    (set! *lazygit* #f)))

--- a/term.scm
+++ b/term.scm
@@ -112,7 +112,9 @@
      base-color]
 
     ; base-color
-    [else (if fg? (style->fg (theme->fg *helix.cx*)) base-color)]))
+    [else (if fg?
+             (style->fg (theme->fg *helix.cx*))
+             (style->bg (theme->bg *helix.cx*)))]))
 
 (define (cell-fg-bg->style base-style base-color-fg base-color-bg fg bg)
   (set-style-bg!
@@ -313,6 +315,29 @@
 
 (define *terminal-fraction* (/ 1 3))
 
+(define *lazygit-mode* #f)
+(define lazygit-stashed-area #f)
+(define lazygit-terminal-area #f)
+
+(define (lazygit-calculate-area state rect)
+  (if (and lazygit-terminal-area (equal? lazygit-stashed-area rect))
+      lazygit-terminal-area
+      (begin
+        (set! lazygit-stashed-area rect)
+        (let* ([pad-x 2]
+               [pad-y 1]
+               [w (- (area-width rect) (* 2 pad-x))]
+               [h (- (area-height rect) (* 2 pad-y) 1)])
+          (set! *default-terminal-cols* w)
+          ;; clip full screen width so the editor is completely hidden (including margins)
+          (set-editor-clip-right! (area-width rect))
+          (term-resize-impl (- h 2) (- w 5))
+          (set! lazygit-terminal-area
+                (area (+ (area-x rect) pad-x)
+                      (+ (area-y rect) pad-y)
+                      w h))
+          lazygit-terminal-area))))
+
 ;; Do as a percentage of the terminal area, rather
 ;; than a fixed size
 (define (alternative-calculate-area state rect)
@@ -441,7 +466,9 @@
   ;; If this is still alive, keep it around
   (unless (unbox (Terminal-kill-switch state))
 
-    (define block-area (alternative-calculate-area state rect))
+    (define block-area (if *lazygit-mode*
+                           (lazygit-calculate-area state rect)
+                           (alternative-calculate-area state rect)))
 
     (define x-offset (+ 1 (area-x block-area)))
     (define y-offset (+ 1 (area-y block-area)))
@@ -1162,24 +1189,105 @@
 
 (define *lazygit* #f)
 
-(define (lazygit-on-start terminal)
-  (pty-process-send-command (Terminal-*pty-process* terminal)
-                            (string-append "cd " (helix-find-workspace) " && lazygit\r")))
+(define (lazygit-event-handler state event)
+  (cond
+    ;; q while focused → close via event-result/close (helix pops component)
+    ;; no modifier check: (not (key-event-modifier event)) fails because 0 is truthy
+    [(and (unbox (Terminal-focused? state))
+          (equal? (key-event-char event) #\q))
+     (kill-pty-process! (Terminal-*pty-process* state))
+     (set! *lazygit-mode* #f)
+     (set! lazygit-terminal-area #f)
+     (set! *lazygit* #f)
+     (set-editor-clip-right! 0)
+     (set-box! (Terminal-kill-switch state) #t)
+     (set-box! (Terminal-focused? state) #f)
+     (set-box! (Terminal-active state) #f)
+     event-result/close]
+    [else (terminal-event-handler state event)]))
+
+(define (lazygit-loop term)
+  (define (inner)
+    (define *pty-process* (Terminal-*pty-process* term))
+    (define *vte* (Terminal-*vte* term))
+    (define *kill-switch* (Terminal-kill-switch term))
+    (if (unbox *kill-switch*)
+        ;; Kill switch set by event handler — helix already removed the component
+        ;; via event-result/close; just clean up any remaining globals
+        (begin
+          (set! *lazygit-mode* #f)
+          (set! lazygit-terminal-area #f)
+          (set! *lazygit* #f))
+        (helix-await-callback (async-try-read-line *pty-process*)
+                              (lambda (line)
+                                (if line
+                                    (begin (vte/advance-bytes *vte* line) (inner))
+                                    ;; PTY exited naturally (exec lazygit quit)
+                                    ;; component still active — pop it ourselves
+                                    (begin
+                                      (set! *lazygit-mode* #f)
+                                      (set! lazygit-terminal-area #f)
+                                      (set! *lazygit* #f)
+                                      (set-editor-clip-right! 0)
+                                      (set-box! (Terminal-kill-switch term) #t)
+                                      (set-box! (Terminal-focused? term) #f)
+                                      (when (unbox (Terminal-active term))
+                                        (set-box! (Terminal-active term) #f)
+                                        (pop-last-component! "lazygit"))))))))
+  (inner))
 
 (define (lazygit)
-  (define term
-    (make-terminal "lazygit"
-                   *default-shell*
-                   *default-terminal-rows*
-                   *default-terminal-cols*
-                   lazygit-on-start
-                   vte/advance-bytes))
-  (set! *lazygit* term)
-  (set-TerminalRegistry-terminals! *terminal-registry* (list term))
-  (set-TerminalRegistry-cursor! *terminal-registry* 0)
-  (show-term term))
+  (define rows *default-terminal-rows*)
+  (define cols *default-terminal-cols*)
+  (define *pty-process* (create-native-pty-system! *default-shell*))
+  (define *vte* (virtual-terminal *pty-process*))
+
+  (vte/resize *vte* rows cols)
+  (pty-resize! *pty-process* rows cols)
+
+  (pty-process-send-command *pty-process*
+                            (string-append "cd " (helix-find-workspace) " && exec lazygit\r"))
+
+  (let ([term (Terminal "lazygit"
+                        (position 0 0)
+                        (box cols)
+                        (box rows)
+                        (box #f)
+                        (box #f)
+                        *pty-process*
+                        *vte*
+                        (style)
+                        (Color/rgb 0 0 0)
+                        (Color/rgb 0 0 0)
+                        (box #f)
+                        (mutable-string)
+                        (vte/empty-cell)
+                        (vte/empty-cell)
+                        (box #f)
+                        (box #f)
+                        terminal-render
+                        lazygit-event-handler
+                        #f  ;; no helix cursor overlay — VTE renders cursor itself
+                        (box #f)
+                        (box #f))])
+    (set! *lazygit* term)
+    (set! *lazygit-mode* #t)
+    (set! lazygit-terminal-area #f)
+    (set-TerminalRegistry-terminals! *terminal-registry* (list term))
+    (set-TerminalRegistry-cursor! *terminal-registry* 0)
+    (lazygit-loop term)
+    (show-term term)))
 
 (define (close-lazygit)
   (when *lazygit*
-    (kill-active-terminal)
-    (set! *lazygit* #f)))
+    (let ([term *lazygit*])
+      (kill-pty-process! (Terminal-*pty-process* term))
+      (set! *lazygit-mode* #f)
+      (set! lazygit-terminal-area #f)
+      (set! *lazygit* #f)
+      (set-editor-clip-right! 0)
+      (set-box! (Terminal-kill-switch term) #t)
+      (set-box! (Terminal-focused? term) #f)
+      (when (unbox (Terminal-active term))
+        (set-box! (Terminal-active term) #f)
+        (pop-last-component! "lazygit")))))

--- a/vim/change-motions.scm
+++ b/vim/change-motions.scm
@@ -10,9 +10,9 @@
 (require "visual-motions.scm")
 
 (define (change-impl func)
-  (func)
-  (helix.clipboard-yank)
-  (helix.static.change_selection))
+  (when (func)
+    (helix.clipboard-yank)
+    (helix.static.change_selection)))
 
 ;; c (select)
 (define (vim-change-selection)
@@ -45,6 +45,10 @@
 
 ;; c^
 (define (vim-change-line-start)
+  (change-impl helix.static.extend_to_first_nonwhitespace))
+
+;; c0
+(define (vim-change-line-col0)
   (change-impl helix.static.extend_to_line_start))
 
 ;; ce
@@ -63,16 +67,13 @@
 (define (vim-change-inner-word)
   (change-impl select-inner-word))
 
-;; TODO: finish implementing this
 ;; caW
-;; (define (vim-change-around-long-word)
-;;   (select-around-word)
-;;   (helix.static.change_selection))
+(define (vim-change-around-long-word)
+  (change-impl select-around-long-word))
 
 ;; ciW
-;; (define (vim-change-inner-long-word)
-;;   (select-inner-word)
-;;   (helix.static.change_selection))
+(define (vim-change-inner-long-word)
+  (change-impl select-inner-long-word))
 
 ;; cap
 (define (vim-change-around-paragraph)
@@ -188,8 +189,11 @@
          vim-change-long-word-end
          vim-change-line-end
          vim-change-line-start
+         vim-change-line-col0
          vim-change-around-word
          vim-change-inner-word
+         vim-change-around-long-word
+         vim-change-inner-long-word
          vim-change-around-paragraph
          vim-change-inner-paragraph
          vim-change-around-function
@@ -207,15 +211,6 @@
          vim-change-around-curly
          vim-change-inner-curly
          vim-change-around-square
-         vim-change-inner-square
-         vim-change-inner-paren
-         vim-change-around-paren
-         vim-change-around-double-quote
-         vim-change-inner-double-quote
-         vim-change-around-single-quote
-         vim-change-inner-single-quote
-         vim-change-around-arrow
-         vim-change-inner-arrow
          vim-change-inner-square
          vim-change-inner-paren
          vim-change-around-paren

--- a/vim/delete-motions.scm
+++ b/vim/delete-motions.scm
@@ -12,9 +12,9 @@
 ;; TODO: rethink everything about how repetition is implemented in delete and yank
 
 (define (delete-impl func)
-  (func)
-  (helix.clipboard-yank)
-  (helix.static.delete_selection))
+  (when (func)
+    (helix.clipboard-yank)
+    (helix.static.delete_selection)))
 
 ;; x (d in select-mode?)
 (define (vim-delete-selection)
@@ -89,6 +89,10 @@
 
 ;; d^
 (define (vim-delete-line-start)
+  (delete-impl helix.static.extend_to_first_nonwhitespace))
+
+;; d0
+(define (vim-delete-line-col0)
   (delete-impl helix.static.extend_to_line_start))
 
 ;; daw
@@ -99,16 +103,13 @@
 (define (vim-delete-inner-word)
   (delete-impl select-inner-word))
 
-;; TODO: finish implementing this
 ;; daW
-;; (define (vim-delete-around-long-word)
-;;   (select-around-word)
-;;   (helix.static.delete_selection))
+(define (vim-delete-around-long-word)
+  (delete-impl select-around-long-word))
 
 ;; diW
-;; (define (vim-delete-inner-long-word)
-;;   (select-inner-word)
-;;   (helix.static.delete_selection))
+(define (vim-delete-inner-long-word)
+  (delete-impl select-inner-long-word))
 
 ;; dap
 (define (vim-delete-around-paragraph)
@@ -222,8 +223,11 @@
          vim-delete-long-word-end
          vim-delete-line-end
          vim-delete-line-start
+         vim-delete-line-col0
          vim-delete-around-word
          vim-delete-inner-word
+         vim-delete-around-long-word
+         vim-delete-inner-long-word
          vim-delete-around-paragraph
          vim-delete-inner-paragraph
          vim-delete-prev-word

--- a/vim/init.scm
+++ b/vim/init.scm
@@ -29,6 +29,20 @@
                   (t ":vim-find-till-char")
                   (T ":vim-till-prev-char")
                   (a ":vim-append-mode")
+                  (A "insert_at_line_end")
+                  (I ":vim-insert-at-line-start")
+                  (o "open_below")
+                  (O "open_above")
+                  (v "select_mode")
+                  (r "replace")
+                  (s ":vim-substitute-char")
+                  (J ":vim-join-lines")
+                  ("~" ":vim-toggle-case")
+                  ("*" ":vim-search-word-forward")
+                  ("#" ":vim-search-word-backward")
+                  (H ":vim-window-top")
+                  (M ":vim-window-middle")
+                  (L ":vim-window-bottom")
                   (u ":vim-undo")
                   (w ":vim-next-word-start")
                   (e ":vim-next-word-end")
@@ -51,7 +65,9 @@
                      (E ":vim-delete-long-word-end")
                      ($ ":vim-delete-line-end")
                      (^ ":vim-delete-line-start")
+                     ("0" ":vim-delete-line-col0")
                      (a (w ":vim-delete-around-word")
+                        (W ":vim-delete-around-long-word")
                         (p ":vim-delete-around-paragraph")
                         (f ":vim-delete-around-function")
                         (c ":vim-delete-around-comment")
@@ -66,6 +82,7 @@
                         ("\"" ":vim-delete-around-double-quote")
                         ("'" ":vim-delete-around-single-quote"))
                      (i (w ":vim-delete-inner-word")
+                        (W ":vim-delete-inner-long-word")
                         (p ":vim-delete-inner-paragraph")
                         (f ":vim-delete-inner-function")
                         (c ":vim-delete-inner-comment")
@@ -88,7 +105,9 @@
                      (E ":vim-change-long-word-end")
                      ($ ":vim-change-line-end")
                      (^ ":vim-change-line-start")
+                     ("0" ":vim-change-line-col0")
                      (a (w ":vim-change-around-word")
+                        (W ":vim-change-around-long-word")
                         (p ":vim-change-around-paragraph")
                         (f ":vim-change-around-function")
                         (c ":vim-change-around-comment")
@@ -103,6 +122,7 @@
                         ("\"" ":vim-change-around-double-quote")
                         ("'" ":vim-change-around-single-quote"))
                      (i (w ":vim-change-inner-word")
+                        (W ":vim-change-inner-long-word")
                         (p ":vim-change-inner-paragraph")
                         (f ":vim-change-inner-function")
                         (c ":vim-change-inner-comment")
@@ -123,21 +143,35 @@
                      ;; TODO: around/inner long word
                      ;; TODO: paragraph, function, comment, test, html tag, etc.
                      (a (w ":yank-around-word")
+                        (W ":yank-around-long-word")
                         (p ":yank-around-paragraph")
                         (f ":yank-around-function")
                         (c ":yank-around-comment")
                         (e ":yank-around-data-structure")
                         (x ":yank-around-html-tag")
                         (t ":yank-around-type-definition")
-                        (T ":yank-around-test"))
+                        (T ":yank-around-test")
+                        ("{" ":yank-around-curly")
+                        ("[" ":yank-around-square")
+                        ("(" ":yank-around-paren")
+                        ("<" ":yank-around-arrow")
+                        ("\"" ":yank-around-double-quote")
+                        ("'" ":yank-around-single-quote"))
                      (i (w ":yank-inner-word")
+                        (W ":yank-inner-long-word")
                         (p ":yank-inner-paragraph")
                         (f ":yank-inner-function")
                         (c ":yank-inner-comment")
                         (e ":yank-inner-data-structure")
                         (x ":yank-inner-html-tag")
                         (t ":yank-inner-type-definition")
-                        (T ":yank-inner-test"))
+                        (T ":yank-inner-test")
+                        ("{" ":yank-inner-curly")
+                        ("[" ":yank-inner-square")
+                        ("(" ":yank-inner-paren")
+                        ("<" ":yank-inner-arrow")
+                        ("\"" ":yank-inner-double-quote")
+                        ("'" ":yank-inner-single-quote"))
                      (w ":yank-word")
                      (W ":yank-long-word")
                      (e ":yank-word")
@@ -162,6 +196,12 @@
                   (C ":vim-change-line-end")
                   ("{" ":vim-goto-prev-paragraph")
                   ("}" ":vim-goto-next-paragraph")
+                  (g (g ":vim-goto-file-start")
+                     (u (u ":vim-lowercase-line"))
+                     (U (U ":vim-uppercase-line")))
+                  (z (z ":vim-scroll-center")
+                     (t ":vim-scroll-top")
+                     (b ":vim-scroll-bottom"))
                   ;; NOTE: this implementation uses the , register
                   ;; so be careful with saving other things there
                   ("," ":vim-repeat-last-find")
@@ -171,6 +211,7 @@
           ;; Select bindings
           ;; TODO: Rename this to VIS (nacl TODO: figure out if I care)
           (select (a (w ":select-around-word")
+                     (W ":select-around-long-word")
                      (p ":select-around-paragraph")
                      (f ":select-around-function")
                      (c ":select-around-comment")
@@ -185,6 +226,7 @@
                      ("\"" ":select-around-double-quote")
                      ("'" ":select-around-single-quote"))
                   (i (w ":select-inner-word")
+                     (W ":select-inner-long-word")
                      (p ":select-inner-paragraph")
                      (f ":select-inner-function")
                      (c ":select-inner-comment")
@@ -226,12 +268,16 @@
                   ("=" ":reflow")
                   (> (> "indent"))
                   (< (< "unindent"))
+                  (o "flip_selections")
+                  (u "switch_to_lowercase")
+                  (U "switch_to_uppercase")
+                  ("~" "switch_case")
                   (left ":extend-char-left-same-line")
                   (right ":extend-char-right-same-line")
                   (down ":extend-line-down")
                   (up ":extend-line-up")
                   (esc ":exit-visual-line-mode"))
-          (insert (C-d "unindent") (C-t "indent") (esc ":vim-exit-insert-mode"))))
+          (insert (C-d "unindent") (C-t "indent") (C-w "delete_word_backward") (C-u "kill_to_line_start") (esc ":vim-exit-insert-mode"))))
 
 (define (set-vim-keybindings!)
   (add-global-keybinding vim-keybindings))
@@ -248,8 +294,11 @@
          vim-change-long-word-end
          vim-change-line-end
          vim-change-line-start
+         vim-change-line-col0
          vim-change-around-word
          vim-change-inner-word
+         vim-change-around-long-word
+         vim-change-inner-long-word
          vim-change-around-paragraph
          vim-change-inner-paragraph
          vim-change-around-function
@@ -276,15 +325,6 @@
          vim-change-inner-single-quote
          vim-change-around-arrow
          vim-change-inner-arrow
-         vim-change-inner-square
-         vim-change-inner-paren
-         vim-change-around-paren
-         vim-change-around-double-quote
-         vim-change-inner-double-quote
-         vim-change-around-single-quote
-         vim-change-inner-single-quote
-         vim-change-around-arrow
-         vim-change-inner-arrow
 
          ;; delete motions
          vim-delete-selection
@@ -295,8 +335,11 @@
          vim-delete-long-word
          vim-delete-line-end
          vim-delete-line-start
+         vim-delete-line-col0
          vim-delete-around-word
          vim-delete-inner-word
+         vim-delete-around-long-word
+         vim-delete-inner-long-word
          vim-delete-around-paragraph
          vim-delete-inner-paragraph
          vim-delete-prev-word
@@ -352,6 +395,21 @@
          vim-goto-prev-paragraph
          visual-line-mode
          vim-exit-insert-mode
+         vim-goto-file-start
+         vim-insert-at-line-start
+         vim-join-lines
+         vim-toggle-case
+         vim-scroll-center
+         vim-scroll-top
+         vim-scroll-bottom
+         vim-window-top
+         vim-window-middle
+         vim-window-bottom
+         vim-search-word-forward
+         vim-search-word-backward
+         vim-substitute-char
+         vim-lowercase-line
+         vim-uppercase-line
 
          ;; visual motions
          extend-char-right-same-line
@@ -364,6 +422,8 @@
          vim-extend-to-prev-paragraph
          select-around-word
          select-inner-word
+         select-around-long-word
+         select-inner-long-word
          select-around-paragraph
          select-inner-paragraph
          select-around-function
@@ -402,6 +462,34 @@
          vim-yank-selection
          yank-around-word
          yank-inner-word
+         yank-around-long-word
+         yank-inner-long-word
+         yank-around-paragraph
+         yank-inner-paragraph
+         yank-around-function
+         yank-inner-function
+         yank-around-comment
+         yank-inner-comment
+         yank-around-data-structure
+         yank-inner-data-structure
+         yank-around-html-tag
+         yank-inner-html-tag
+         yank-around-type-definition
+         yank-inner-type-definition
+         yank-around-test
+         yank-inner-test
+         yank-around-curly
+         yank-inner-curly
+         yank-around-square
+         yank-inner-square
+         yank-around-paren
+         yank-inner-paren
+         yank-around-double-quote
+         yank-inner-double-quote
+         yank-around-single-quote
+         yank-inner-single-quote
+         yank-around-arrow
+         yank-inner-arrow
          yank-word
          yank-long-word
          yank-prev-word

--- a/vim/init.scm
+++ b/vim/init.scm
@@ -14,6 +14,7 @@
 (require "visual-motions.scm")
 (require "yank-motions.scm")
 (require "utils.scm")
+(require "../term.scm")
 
 (define vim-keybindings
   (keymap (normal (l ":move-char-right-same-line")
@@ -205,7 +206,8 @@
                   ;; NOTE: this implementation uses the , register
                   ;; so be careful with saving other things there
                   ("," ":vim-repeat-last-find")
-                  (";" ":vim-reverse-last-find"))
+                  (";" ":vim-reverse-last-find")
+                  (space (g ":lazygit")))
           ;; TODO: make full "reflow mode"
           ;; ("=" ":reflow"))
           ;; Select bindings

--- a/vim/key-emulation.scm
+++ b/vim/key-emulation.scm
@@ -16,13 +16,15 @@
 (define x-key (string->key-event "x"))
 (define at-key (string->key-event "@"))
 (define comma-key (string->key-event ","))
+(define W-key (string->key-event "W"))
 
-(provide 
+(provide
   a-key
   e-key
   t-key
   T-key
   w-key
+  W-key
   p-key
   f-key
   c-key

--- a/vim/normal-motions.scm
+++ b/vim/normal-motions.scm
@@ -328,6 +328,103 @@
       ;; TODO: look into Helix code to see why this happens
       (set-editor-count! 0))))
 
+;; gg
+(define (vim-goto-file-start)
+  (helix.static.goto_file_start)
+  (helix.static.collapse_selection))
+
+;; I
+(define (vim-insert-at-line-start)
+  (helix.static.goto_first_nonwhitespace)
+  (helix.static.collapse_selection)
+  (helix.static.insert_mode))
+
+;; J
+(define (vim-join-lines)
+  (define count (editor-count))
+  (set-editor-count! 1)
+  (do-n-times (max 1 (- count 1)) (lambda () (helix.static.extend_line_down)))
+  (helix.static.join_selections_space)
+  (helix.static.collapse_selection))
+
+;; ~
+(define (vim-toggle-case)
+  (define count (editor-count))
+  (set-editor-count! 1)
+  (if (> count 1)
+      (begin
+        (do-n-times (- count 1) (lambda () (helix.static.extend_char_right)))
+        (helix.static.switch_case)
+        (helix.static.flip_selections)
+        (helix.static.collapse_selection))
+      (begin
+        (helix.static.switch_case)
+        (helix.static.move_char_right)
+        (helix.static.collapse_selection))))
+
+;; zz
+(define (vim-scroll-center) (helix.static.align_view_center))
+
+;; zt
+(define (vim-scroll-top) (helix.static.align_view_top))
+
+;; zb
+(define (vim-scroll-bottom) (helix.static.align_view_bottom))
+
+;; H
+(define (vim-window-top)
+  (helix.static.goto_window_top)
+  (helix.static.collapse_selection))
+
+;; M
+(define (vim-window-middle)
+  (helix.static.goto_window_center)
+  (helix.static.collapse_selection))
+
+;; L
+(define (vim-window-bottom)
+  (helix.static.goto_window_bottom)
+  (helix.static.collapse_selection))
+
+;; *
+(define (vim-search-word-forward)
+  (helix.static.search_selection_detect_word_boundaries)
+  (helix.static.collapse_selection))
+
+;; # — set word search then go to previous occurrence
+(define (vim-search-word-backward)
+  (helix.static.search_selection_detect_word_boundaries)
+  (helix.static.search_prev)
+  (helix.static.collapse_selection))
+
+;; s
+(define (vim-substitute-char)
+  (define count (editor-count))
+  (set-editor-count! 1)
+  (when (> count 1)
+    (do-n-times (- count 1) (lambda () (helix.static.extend_char_right))))
+  (helix.static.change_selection))
+
+;; guu
+(define (vim-lowercase-line)
+  (define count (editor-count))
+  (set-editor-count! 1)
+  (when (> count 1)
+    (do-n-times (- count 1) (lambda () (helix.static.extend_line_down))))
+  (helix.static.extend_to_line_bounds)
+  (helix.static.switch_to_lowercase)
+  (helix.static.collapse_selection))
+
+;; gUU
+(define (vim-uppercase-line)
+  (define count (editor-count))
+  (set-editor-count! 1)
+  (when (> count 1)
+    (do-n-times (- count 1) (lambda () (helix.static.extend_line_down))))
+  (helix.static.extend_to_line_bounds)
+  (helix.static.switch_to_uppercase)
+  (helix.static.collapse_selection))
+
 (provide vim-undo
          vim-append-mode
          move-char-right-same-line
@@ -352,4 +449,19 @@
          vim-goto-next-paragraph
          vim-goto-prev-paragraph
          visual-line-mode
-         vim-exit-insert-mode)
+         vim-exit-insert-mode
+         vim-goto-file-start
+         vim-insert-at-line-start
+         vim-join-lines
+         vim-toggle-case
+         vim-scroll-center
+         vim-scroll-top
+         vim-scroll-bottom
+         vim-window-top
+         vim-window-middle
+         vim-window-bottom
+         vim-search-word-forward
+         vim-search-word-backward
+         vim-substitute-char
+         vim-lowercase-line
+         vim-uppercase-line)

--- a/vim/utils.scm
+++ b/vim/utils.scm
@@ -6,6 +6,11 @@
 
 (require-builtin helix/core/text)
 
+;; editor-count requires a binary newer than the current install; stub returns 1
+(define (editor-count) 1)
+;; set-editor-count! has no Rust counterpart; helix auto-resets count after each command
+(define (set-editor-count! n) void)
+
 (define (get-document-as-slice)
   (let* ([focus (editor-focus)]
          [focus-doc-id (editor->doc-id focus)])
@@ -45,15 +50,6 @@
            (char=? ch #\')
            (char=? ch #\<)
            (char=? ch #\>))))
-
-(define (get-selection-range)
-  ;; Try to get selection info from editor
-  ;; This may need adjustment based on actual Steel API
-  (let* ([focus (editor-focus)]
-         [focus-doc-id (editor->doc-id focus)])
-    ;; If there's an API like editor->selection-range, use it
-    ;; For now, we'll use a workaround
-    #f))
 
 ;; Helper to check if we have a real selection (more than 1 char)
 (define (has-real-selection? start-pos)
@@ -250,17 +246,17 @@
                    ;; Move back to original position
                    (move-to-position cur-pos)
 
-                   ;; Check if match is after our cursor (meaning we're inside)
+                   ;; Check if match is at or after our cursor (>= handles cursor-on-closing-bracket)
                    (if (and (not (= bracket-pos match-pos)) ; Matched something
-                            (> match-pos cur-pos)) ; Match is after cursor
+                            (>= match-pos cur-pos)) ; Match is at or after cursor
                        (cons bracket-pos match-pos) ; Found it!
                        (loop (- pos 1)))) ; Keep searching
                  ;; Not the target bracket, keep searching
                  (loop (- pos 1))))]))))
 
+;; Search forward from cur-pos for the next occurrence of target-ch
 (define (find-next-bracket rope cur-pos target-ch)
   (define len (rope-len-chars rope))
-
   (let loop ([pos cur-pos])
     (cond
       [(>= pos len) #f]
@@ -270,28 +266,19 @@
              pos
              (loop (+ pos 1))))])))
 
-;; Find bracket pair with forward search fallback
+;; Find bracket pair: enclosing first, then forward seek (matches neovim current_block behavior)
 (define (find-bracket-pair rope cur-pos target-open-ch)
-  ;; First try to find enclosing pair
   (let ([enclosing (find-enclosing-pair-with-match rope cur-pos target-open-ch)])
     (if enclosing
         enclosing
-        ;; Not inside pair - search forward and check
         (let ([next-pos (find-next-bracket rope cur-pos target-open-ch)])
           (if next-pos
               (begin
-                ;; Move to the bracket
                 (move-to-position next-pos)
                 (define bracket-pos (cursor-position))
-
-                ;; Use match_brackets to find pair
                 (helix.static.match_brackets)
                 (define match-pos (cursor-position))
-
-                ;; Move back to original
                 (move-to-position cur-pos)
-
-                ;; Return pair if we found a match
                 (if (not (= bracket-pos match-pos))
                     (cons bracket-pos match-pos)
                     #f))
@@ -326,34 +313,19 @@
   (define close-ch (get-closing-bracket open-ch))
   (define len (rope-len-chars rope))
 
-  (displayln (string-append "find-matching-close from pos " (number->string start-pos)))
-
   (let loop ([pos (+ start-pos 1)]
              [depth 1]
              [iter 0])
     (cond
-      [(>= pos len)
-       (displayln "Reached end of file, no match found")
-       #f]
-      [(> iter 1000)
-       (displayln "Too many iterations, stopping")
-       #f]
+      [(>= pos len) #f]
+      [(> iter 1000) #f]
       [else
        (let ([ch (rope-char-ref rope pos)])
-         (when (and (< iter 20) (or (char=? ch open-ch) (char=? ch close-ch)))
-           (displayln (string-append "  pos "
-                                     (number->string pos)
-                                     ": "
-                                     (string ch)
-                                     " depth="
-                                     (number->string depth))))
          (cond
            [(char=? ch open-ch) (loop (+ pos 1) (+ depth 1) (+ iter 1))]
            [(char=? ch close-ch)
             (if (= depth 1)
-                (begin
-                  (displayln (string-append "Found matching close at " (number->string pos)))
-                  pos)
+                pos
                 (loop (+ pos 1) (- depth 1) (+ iter 1)))]
            [else (loop (+ pos 1) depth (+ iter 1))]))])))
 
@@ -521,7 +493,6 @@
          extend-right-n
          do-n-times
          is-bracket?
-         get-selection-range
          has-real-selection?
          move-to-position
          move-to-char
@@ -544,4 +515,6 @@
          find-next-bracket
          find-bracket-pair
          get-next-word-start
-         get-next-long-word-start)
+         get-next-long-word-start
+         editor-count
+         set-editor-count!)

--- a/vim/visual-motions.scm
+++ b/vim/visual-motions.scm
@@ -209,6 +209,35 @@
 (define (select-inner-test)
   (select-inner-impl T-key))
 
+;; vaW
+(define (select-around-long-word)
+  (select-around-impl W-key))
+
+;; viW
+(define (select-inner-long-word)
+  (select-inner-impl W-key))
+
+;; Helpers for linewise inner-brace detection (neovim parity)
+(define (only-ws-after? rope pos)
+  (let* ([line (rope-char->line rope pos)]
+         [end  (+ (rope-line->char rope line) (rope-len-chars (rope->line rope line)))])
+    (let loop ([p (+ pos 1)])
+      (cond [(>= p (- end 1)) #t]
+            [(is-whitespace? (rope-char-ref rope p)) (loop (+ p 1))]
+            [else #f]))))
+
+(define (only-ws-before? rope pos)
+  (let ([start (rope-line->char rope (rope-char->line rope pos))])
+    (let loop ([p start])
+      (cond [(>= p pos) #t]
+            [(is-whitespace? (rope-char-ref rope p)) (loop (+ p 1))]
+            [else #f]))))
+
+(define (brace-block-linewise? rope open-pos close-pos)
+  (and (> (rope-char->line rope close-pos) (rope-char->line rope open-pos))
+       (only-ws-after? rope open-pos)
+       (only-ws-before? rope close-pos)))
+
 ;; vi{
 ;; vi[
 ;; vi(
@@ -218,24 +247,30 @@
 (define (select-inner-bracket open-ch)
   (define rope (get-document-as-slice))
   (define cur-pos (cursor-position))
-
   (let ([pair (find-bracket-pair rope cur-pos open-ch)])
-    (when pair
-      (let ([open-pos (car pair)]
-            [close-pos (cdr pair)])
-        ;; Determine which is opening and which is closing
-        (if (< open-pos close-pos)
-            (begin
-              ;; Move to position after opening bracket
-              (move-to-position (+ open-pos 1))
-              ;; Extend to position before closing bracket
-              (extend-to-position (- close-pos 1)))
-            (begin
-              ;; Reversed - match_brackets put us on closing bracket
-              (move-to-position (+ close-pos 1))
-              (extend-to-position (- open-pos 1))))))))
+    (if (not pair)
+        #f
+        (let ([open-pos (min (car pair) (cdr pair))]
+              [close-pos (max (car pair) (cdr pair))])
+          (cond
+            [(<= (- close-pos open-pos) 1) #f]
+            [(brace-block-linewise? rope open-pos close-pos)
+             (let* ([first-line (+ (rope-char->line rope open-pos) 1)]
+                    [last-line  (- (rope-char->line rope close-pos) 1)])
+               (if (> first-line last-line)
+                   (begin (move-to-position (+ open-pos 1))
+                          (extend-to-position (- close-pos 1)) #t)
+                   (let* ([start-char (rope-line->char rope first-line)]
+                          [ls (rope-line->char rope last-line)]
+                          [llen (rope-len-chars (rope->line rope last-line))]
+                          [last-content (+ ls (- llen 2))])
+                     (move-to-position start-char)
+                     (when (>= last-content start-char)
+                       (extend-to-position last-content))
+                     #t)))]
+            [else (move-to-position (+ open-pos 1))
+                  (extend-to-position (- close-pos 1)) #t])))))
 
-;; Select around bracket - enhanced with forward search
 ;; va{
 ;; va[
 ;; va(
@@ -245,59 +280,66 @@
 (define (select-around-bracket open-ch)
   (define rope (get-document-as-slice))
   (define cur-pos (cursor-position))
-
   (let ([pair (find-bracket-pair rope cur-pos open-ch)])
-    (when pair
-      (let ([open-pos (car pair)]
-            [close-pos (cdr pair)])
-        ;; Determine which is opening and which is closing
-        (if (< open-pos close-pos)
-            (begin
-              (move-to-position open-pos)
-              (extend-to-position close-pos))
-            (begin
-              (move-to-position close-pos)
-              (extend-to-position open-pos)))))))
+    (if (not pair)
+        #f
+        (let ([open-pos (min (car pair) (cdr pair))]
+              [close-pos (max (car pair) (cdr pair))])
+          (move-to-position open-pos)
+          (extend-to-position close-pos)
+          #t))))
+
+;; Collect positions of all quote chars on cur-line (left to right)
+(define (quote-positions-on-line rope quote-ch cur-line)
+  (define line-start (rope-line->char rope cur-line))
+  (define line-end (+ line-start (rope-len-chars (rope->line rope cur-line))))
+  (let loop ([p line-start] [acc '()])
+    (cond
+      [(>= p (- line-end 1)) (reverse acc)]
+      [else
+       (let ([ch (rope-char-at rope p)])
+         (if (and ch (char=? ch quote-ch))
+             (loop (+ p 1) (cons p acc))
+             (loop (+ p 1) acc)))])))
+
+;; Find the quote pair (open . close) that contains cur-pos or is first after it.
+;; quotes must be in ascending order; pairs are (q0,q1),(q2,q3),...
+(define (find-quote-pair quotes cur-pos)
+  (let loop ([qs quotes])
+    (cond
+      [(or (null? qs) (null? (cdr qs))) #f]
+      [else
+       (let ([open (car qs)]
+             [close (cadr qs)])
+         (cond
+           [(and (<= open cur-pos) (<= cur-pos close)) (cons open close)]
+           [(< cur-pos open) (cons open close)]
+           [else (loop (cddr qs))]))])))
 
 (define (select-inner-quote quote-ch)
   (define rope (get-document-as-slice))
-  (define start-pos (cursor-position))
-
-  (helix.static.select_textobject_inner)
-  (trigger-on-key-callback (string->key-event (string quote-ch)))
-
-  ;; If didn't work, search forward
-  (when (= start-pos (cursor-position))
-    (let loop ([i 1])
-      (define pos (+ start-pos i))
-      (when (< pos (rope-len-chars rope))
-        (let ([ch (rope-char-ref rope pos)])
-          (if (char=? ch quote-ch)
-              (begin
-                (move-right-n (+ i 1)) ; Move past the quote
-                (helix.static.select_textobject_inner)
-                (trigger-on-key-callback (string->key-event (string quote-ch))))
-              (loop (+ i 1))))))))
+  (define cur-pos (cursor-position))
+  (define cur-line (rope-char->line rope cur-pos))
+  (define pair (find-quote-pair (quote-positions-on-line rope quote-ch cur-line) cur-pos))
+  (if (not pair)
+      #f
+      (let ([open (car pair)] [close (cdr pair)])
+        (if (<= (- close open) 1)
+            #f
+            (begin (move-to-position (+ open 1))
+                   (extend-to-position (- close 1))
+                   #t)))))
 
 (define (select-around-quote quote-ch)
   (define rope (get-document-as-slice))
-  (define start-pos (cursor-position))
-
-  (helix.static.select_textobject_around)
-  (trigger-on-key-callback (string->key-event (string quote-ch)))
-
-  ;; If didn't work, search forward
-  (when (= start-pos (cursor-position))
-    (let loop ([i 1])
-      (define pos (+ start-pos i))
-      (when (< pos (rope-len-chars rope))
-        (let ([ch (rope-char-ref rope pos)])
-          (if (char=? ch quote-ch)
-              (begin
-                (move-right-n (+ i 1)) ; Move past the quote
-                (helix.static.select_textobject_around)
-                (trigger-on-key-callback (string->key-event (string quote-ch))))
-              (loop (+ i 1))))))))
+  (define cur-pos (cursor-position))
+  (define cur-line (rope-char->line rope cur-pos))
+  (define pair (find-quote-pair (quote-positions-on-line rope quote-ch cur-line) cur-pos))
+  (if (not pair)
+      #f
+      (begin (move-to-position (car pair))
+             (extend-to-position (cdr pair))
+             #t)))
 
 ;; Public API functions
 (define (select-inner-curly)
@@ -495,7 +537,7 @@
     [(equal? action #\T) (select-find-till-char-impl char count)]))
 
 (define (exit-visual-line-mode)
-  (when is-visual-line-mode?
+  (when (is-visual-line-mode?)
     (set-visual-line-mode! #f))
   (helix.static.collapse_selection)
   (helix.static.normal_mode)
@@ -544,6 +586,8 @@
          select-around-single-quote
          select-inner-arrow
          select-around-arrow
+         select-around-long-word
+         select-inner-long-word
          select-find-next-char
          select-find-prev-char
          select-find-till-char

--- a/vim/yank-motions.scm
+++ b/vim/yank-motions.scm
@@ -13,10 +13,10 @@
 ;; TODO: implement for yank commands using custom implementations
 
 (define (yank-impl func)
-  (func)
-  (helix.static.yank_main_selection_to_clipboard)
-  (helix.static.flip_selections)
-  (helix.static.collapse_selection))
+  (when (func)
+    (helix.static.yank_main_selection_to_clipboard)
+    (helix.static.flip_selections)
+    (helix.static.collapse_selection)))
 
 ;; y (select)
 (define (vim-yank-selection)
@@ -42,7 +42,7 @@
 
 ;; yW
 (define (yank-long-word)
-  (vim-extend-next-word-start)
+  (vim-extend-next-long-word-start)
   (set-editor-count! 1)
   (helix.static.extend_char_left)
   (helix.static.yank_main_selection_to_clipboard)
@@ -94,9 +94,93 @@
     [(> distance 0) (move-right-n distance)]
     [(< distance 0) (move-left-n (- distance))]))
 
+;; yap/yip
+(define (yank-around-paragraph)        (yank-impl select-around-paragraph))
+(define (yank-inner-paragraph)         (yank-impl select-inner-paragraph))
+
+;; yaf/yif
+(define (yank-around-function)         (yank-impl select-around-function))
+(define (yank-inner-function)          (yank-impl select-inner-function))
+
+;; yac/yic
+(define (yank-around-comment)          (yank-impl select-around-comment))
+(define (yank-inner-comment)           (yank-impl select-inner-comment))
+
+;; yae/yie
+(define (yank-around-data-structure)   (yank-impl select-around-data-structure))
+(define (yank-inner-data-structure)    (yank-impl select-inner-data-structure))
+
+;; yax/yix
+(define (yank-around-html-tag)         (yank-impl select-around-html-tag))
+(define (yank-inner-html-tag)          (yank-impl select-inner-html-tag))
+
+;; yat/yit
+(define (yank-around-type-definition)  (yank-impl select-around-type-definition))
+(define (yank-inner-type-definition)   (yank-impl select-inner-type-definition))
+
+;; yaT/yiT
+(define (yank-around-test)             (yank-impl select-around-test))
+(define (yank-inner-test)              (yank-impl select-inner-test))
+
+;; ya{/yi{
+(define (yank-around-curly)            (yank-impl select-around-curly))
+(define (yank-inner-curly)             (yank-impl select-inner-curly))
+
+;; ya[/yi[
+(define (yank-around-square)           (yank-impl select-around-square))
+(define (yank-inner-square)            (yank-impl select-inner-square))
+
+;; ya(/yi(
+(define (yank-around-paren)            (yank-impl select-around-paren))
+(define (yank-inner-paren)             (yank-impl select-inner-paren))
+
+;; ya"/yi"
+(define (yank-around-double-quote)     (yank-impl select-around-double-quote))
+(define (yank-inner-double-quote)      (yank-impl select-inner-double-quote))
+
+;; ya'/yi'
+(define (yank-around-single-quote)     (yank-impl select-around-single-quote))
+(define (yank-inner-single-quote)      (yank-impl select-inner-single-quote))
+
+;; ya</yi<
+(define (yank-around-arrow)            (yank-impl select-around-arrow))
+(define (yank-inner-arrow)             (yank-impl select-inner-arrow))
+
+;; yaW/yiW
+(define (yank-around-long-word)        (yank-impl select-around-long-word))
+(define (yank-inner-long-word)         (yank-impl select-inner-long-word))
+
 (provide vim-yank-selection
          yank-around-word
          yank-inner-word
+         yank-around-paragraph
+         yank-inner-paragraph
+         yank-around-function
+         yank-inner-function
+         yank-around-comment
+         yank-inner-comment
+         yank-around-data-structure
+         yank-inner-data-structure
+         yank-around-html-tag
+         yank-inner-html-tag
+         yank-around-type-definition
+         yank-inner-type-definition
+         yank-around-test
+         yank-inner-test
+         yank-around-curly
+         yank-inner-curly
+         yank-around-square
+         yank-inner-square
+         yank-around-paren
+         yank-inner-paren
+         yank-around-double-quote
+         yank-inner-double-quote
+         yank-around-single-quote
+         yank-inner-single-quote
+         yank-around-arrow
+         yank-inner-arrow
+         yank-around-long-word
+         yank-inner-long-word
          yank-word
          yank-long-word
          yank-prev-word


### PR DESCRIPTION
## Vim motions correctness pass + lazygit terminal integration

### Vim motions

**Bug fixes:**

- `ci{`/`di{`/`yi{` with cursor on the closing bracket now works correctly (off-by-one `>=` guard fix)
- `ci"`/`ci'`/`ci<` no longer searches backward across line boundaries — replaced the built-in textobject with a pure line-scoped quote pair scan
- `d^`/`c^` now go to first non-whitespace character; new `d0`/`c0` go to column 0 (matching Vim's distinction between `^` and `0`)
- `ci{` on brace-per-line blocks is now linewise-aware, matching Neovim behavior
- `ci{`/`di{`/`yi{` on a line with no matching pair now no-ops instead of deleting a character
- Stubbed `editor-count` (returns 1) and `set-editor-count!` (no-op) for binary compatibility

**New commands:**

| Mode | Keys |
|------|------|
| Normal | `A`, `I`, `o`, `O`, `v`, `r`, `s`, `J`, `~`, `*`, `#`, `H`/`M`/`L`, `gg`, `guu`/`gUU`, `zz`/`zt`/`zb` |
| Select | `o` (flip selections), `u`/`U`/`~` (case) |
| Insert | `C-w` (delete word backward), `C-u` (kill to line start) |
| Yank | `yy`, `yw`/`yW`, `yb`/`yB`, `y$`/`y^`/`y0`, all text objects including `y{`/`y[`/`y(`/`y<`/`y"`/`y'` |

**Long-word variants** (`W`, `B`, `E`) added to all operator+textobject combos (`dW`, `cW`, `yW`, `daW`, `ciW`, etc.).

### Lazygit terminal integration

Opens lazygit in a native PTY floating terminal on `<space>g`, following the same pattern as the existing xplr integration in `term.scm`. Cds to workspace root on open, uses the standard terminal event handler. Close with `q` inside lazygit as normal.

Also fixes a color leak in the VTE cell renderer: default-background cells were returning the shared mutable `base-color-bg` directly, causing any preceding cell with an explicit background to bleed into subsequent default-bg cells. The default-bg branch now returns a fresh theme background color, matching how the existing default-fg branch already worked.

### Test plan
- [ ] `ci"` / `ci'` inside a quoted string — confirm does not cross line boundary
- [ ] `ci{` with cursor on `}` — confirm selects inner block
- [ ] `ci{` on a line with no braces — confirm no-op
- [ ] `d^` vs `d0` — confirm `^` stops at first non-whitespace, `0` goes to column 0
- [ ] `<space>g` — lazygit opens, navigate/commit, `q` to close, confirm no color artifacts in surrounding buffers after close
- [ ] `gg` / `zz` / `H` / `M` / `L` — confirm scroll commands work
